### PR TITLE
Changed default xml mode to true

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var util = require('util');
 
 function run(html, config) {
   var $ = cheerio.load(html, {
+    xmlMode: true,
     decodeEntities: false
   });
 


### PR DESCRIPTION
By default, it does not handle valid XML syntax, but invalid HTML syntax. For example, it does not handle self-enclosing tags.
It is quite common to use self-enclosing tags when using along with modern JS frameworks like Vue.